### PR TITLE
build / bugfix: fix path errors for external applications

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,7 @@
 name: MQTT / TLS client Unit Test
 
 on:
-  push:
+  pull_request:
     branches:
       - master
     paths:
@@ -55,12 +55,18 @@ jobs:
           make config  MQC_CFG_FULLPATH=${{ github.workspace }}/mqttclient.conf
           make download_3party
 
-      - name: Build and Test
+      - name: Build 3rd-party libraries
         run: |
-          make gen_3pty_libs -C ./third_party DEBUG=yes
-          make gen_lib BUILD_DIR=build/itst
-          make demo BUILD_DIR=build/itst
-          make utest BUILD_DIR=build/utst
+          make gen_3pty_libs
+
+      - name: Build image for target platform
+        run: |
+          make gen_lib BUILD_DIR=${{ github.workspace }}/build/itst
+          make demo BUILD_DIR=${{ github.workspace }}/build/itst
+
+      - name: Run Unit Test
+        run: |
+          make utest BUILD_DIR=${{ github.workspace }}/build/utst
 
       - name: Upload coverage to Codecov
         if: success() # This step runs only if previous steps succeed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This section guides you on integrating your custom application with this MQTT cl
 - Edit `mqttclient.conf` to specify your `middleware`, `cryptolib`, `brokeraddr`, `brokerport`, and for embedded systems, `os`, `hw_platform`, `rtos_hw_build_path`, `toolchain_basepath`, and `esp_proj_home` (if using ESP8266).
 - Run `make config` to generate build files based on your configuration:
   ```bash
-  make config
+  make config MQC_CFG_FULLPATH=$PWD/mqttclient.conf
   ```
 
 #### Download and build third-party libraries
@@ -22,40 +22,36 @@ This section guides you on integrating your custom application with this MQTT cl
   ```bash
   make download_3party
   ```
-- Build them. For Linux:
+- Build them. For both Linux of embedded systems (e.g., ESP8266_AT_parser)
   ```bash
-  make gen_3pty_libs -C ./third_party
-  ```
-- For embedded systems (e.g., ESP8266_AT_parser), you might need to specify platform variables if not set in `mqttclient.conf`:
-  ```bash
-  make gen_3pty_libs -C ./third_party  HW_PLATFORM=<your_hw> \
-      RTOS_HW_BUILD_PATH=<your_rtos_path> \
-      TOOLCHAIN_BASEPATH=<your_toolchain_path>
+  make gen_3pty_libs
   ```
 
 #### Build the MQTT client library
 - Build the core `libmqttclient.a`:
   ```bash
-  make gen_lib APPCFG_BASEPATH=/path/to/your-app/cfg
+  make gen_lib BUILD_DIR=/path/to/external-app/build  APPCFG_BASEPATH=/path/to/your-app/cfg
   ```
-- `APPCFG_BASEPATH` indicates the path to your application configuration, essential for embedded system build
+  - `APPCFG_BASEPATH` indicates the path to your application configuration, essential for embedded system build
+  - `BUILD_DIR`, absollute path of the build directory for output library.
 
 #### Build your custom application
 - Place your application's source files (e.g., `my_app.c`) in a directory (e.g., `my_apps/`).
 - Use `make buildapp` to compile your application. You must specify :
   - `APP_NAME` (your executable name)
   - `APP_BASEPATH` (the directory containing your source files).
+  - `BUILD_DIR`, absollute path of the build directory for target image application .
 - For Linux:
   ```bash
-  make demo
+  make demo BUILD_DIR=/path/to/external-app/build
   ```
 - For embedded systems, you *must* also provide the OS and hardware-specific variables (if not already in `mqttclient.conf`):
   ```bash
-  make buildapp APP_NAME=my_app APP_BASEPATH=my_apps \
+  make buildapp BUILD_DIR=/path/to/external-app/build APP_NAME=my_app APP_BASEPATH=my_apps \
       OS=<your_os> HW_PLATFORM=<your_hw> RTOS_HW_BUILD_PATH=<your_rtos_path> \
       TOOLCHAIN_BASEPATH=<your_toolchain_path> ESP_PROJ_HOME=<your_esp_path>
   
-  make demo
+  make demo BUILD_DIR=/path/to/external-app/build
   ```
 - The compiled application will be found in the `build/` directory.
 

--- a/auto/codegen/template/makefile
+++ b/auto/codegen/template/makefile
@@ -36,12 +36,12 @@ _EXCLUDE_CMDS_MIDDLEWARE_INCLUDE = utest utest_helper clean config
 
 ifeq ($(strip $(filter $(_EXCLUDE_CMDS_MIDDLEWARE_INCLUDE), $(MAKECMDGOALS))), )
     #### include hardware platfrom specific files, (NOTE) don't use cross-compile toolchain in unit test
-    include  ${PWD}/auto/platform/$(HW_PLATFORM).makefile
+    include  $(MQC_PROJ_HOME)/auto/platform/$(HW_PLATFORM).makefile
     #### include middleware files, the middleware can be any API software integrated
     #### with OS (e.g. RTOS, Linux kernel) .
-    include  ${PWD}/auto/middleware/$(MIDDLEWARE).makefile
+    include  $(MQC_PROJ_HOME)/auto/middleware/$(MIDDLEWARE).makefile
 else  # when running unit-test, clean, config
-    include  ${PWD}/auto/middleware/unknown.makefile
+    include  $(MQC_PROJ_HOME)/auto/middleware/unknown.makefile
 endif
 
 COMMON_3PARTY_BUILD_CMD = {{{ *.metadata.cmd.build@ListAppendSemicolon }}}

--- a/auto/middleware/ESP8266_AT_parser.makefile
+++ b/auto/middleware/ESP8266_AT_parser.makefile
@@ -28,8 +28,11 @@ endif
 # $(info FILTERED_GOALS : $(FILTERED_GOALS))
 # $(info ----- MQTT ESP8266-AT-parser integration end -----)
 
-_APPCFG_LIBS_PATHS = $(MQC_PROJ_HOME)/$(TARGET_LIB_PATH) \
-					 $(addprefix $(MQC_PROJ_HOME)/, $(THIRD_PARTY_LIBS_PATH))
+_APPCFG_LIBS_PATHS = $(TARGET_LIB_PATH) \
+	$(addprefix $(MQC_PROJ_HOME)/, $(THIRD_PARTY_LIBS_PATH))
+
+_APP_REQUIRED_C_SRC_FILES = $(ESP_C_SOURCES) \
+	$(MQC_PROJ_HOME)/generate/src/mqtt_generate.c
 
 # Get the list of application names from TEST_ENTRY_SOURCES
 # TEST_ENTRY_SOURCES is defined in the main makefile, which includes this one.
@@ -54,11 +57,10 @@ buildapp: export MQC_PROJ_HOME := $(MQC_PROJ_HOME)
 buildapp: export ESP_PROJ_HOME := $(ESP_PROJ_HOME)
 buildapp: export RTOS_HW_BUILD_PATH := $(RTOS_HW_BUILD_PATH)
 buildapp: export APP_REQUIRED_C_HEADER_PATHS := $(C_HEADERS_PATHS)
-buildapp: export APP_REQUIRED_C_SOURCE_FILES := $(ESP_C_SOURCES)
+buildapp: export APP_REQUIRED_C_SOURCE_FILES := $(_APP_REQUIRED_C_SRC_FILES)
 buildapp:
 	@make -C $(RTOS_HW_BUILD_PATH)  startbuild \
-          DEBUG=$(_DBG_FLG_RTOS_HW_PLATFORM) \
-		  BUILD_DIR=$(MQC_PROJ_HOME)/$(BUILD_DIR) \
+          DEBUG=$(_DBG_FLG_RTOS_HW_PLATFORM)  BUILD_DIR=$(BUILD_DIR) \
 		  OS=$(OS)  HW_PLATFORM=$(HW_PLATFORM) \
 		  APP_NAME=$(APP_NAME) APPCFG_PATH=$(APP_BASEPATH) \
 		  TOOLCHAIN_BASEPATH=$(TOOLCHAIN_BASEPATH) \

--- a/auto/middleware/Linux.makefile
+++ b/auto/middleware/Linux.makefile
@@ -22,7 +22,11 @@ GDB_CMD = gdb
 
 DBG_CLIENT_CMD = $(GDB_CMD)
 
-demo : $(TARGET_LIB_PATH)  $(TEST_COMMON_OBJECTS)  $(TEST_ENTRY_OBJECTS) $(ITEST_ASM_OBJS) \
+_AUTOGEN_C_SRCS = $(MQC_PROJ_HOME)/generate/src/mqtt_generate.c
+_AUTOGEN_OBJS = $(addprefix $(BUILD_DIR)/, $(_AUTOGEN_C_SRCS:.c=.o))
+
+demo : $(TARGET_LIB_PATH)  $(TEST_COMMON_OBJECTS)  $(TEST_ENTRY_OBJECTS) \
+	   $(ITEST_ASM_OBJS) $(_AUTOGEN_OBJS)  \
        $(foreach atest, $(TEST_ENTRY_OBJECTS), $(atest:.o=).elf  $(atest:.o=).hex  $(atest:.o=).text  $(atest:.o=).bin)
 
 

--- a/build-help-doc
+++ b/build-help-doc
@@ -62,11 +62,11 @@ These commands are generally applicable regardless of the chosen middleware or p
 
     Variables:
     *   DEBUG: Set to yes for a debug build.
-    *   BUILD_DIR: Specifies the build directory for unit test artifacts.
+    *   BUILD_DIR: Specifies absolute path of the build directory for unit test artifacts.
 
     Example:
     ```
-    make utest DEBUG=yes BUILD_DIR=build/utst
+    make utest DEBUG=yes BUILD_DIR=$PWD/build/utst
     ```
 
 
@@ -83,7 +83,7 @@ These commands are used when middleware is set to Linux in mqttclient.conf.
 
     Example:
     ```
-    make gen_3pty_libs -C ./third_party DEBUG=yes
+    make gen_3pty_libs DEBUG=yes
     ```
 
 
@@ -93,11 +93,11 @@ These commands are used when middleware is set to Linux in mqttclient.conf.
 
     Variables:
     *   DEBUG: Set to yes for a debug build.
-    *   BUILD_DIR: Specifies the build directory for object files and output library `libmqttclient.a`.
+    *   BUILD_DIR: Specifies absollute path of the build directory for object files and output library `libmqttclient.a`.
 
     Example:
     ```
-    make gen_lib DEBUG=yes BUILD_DIR=build/itst
+    make gen_lib DEBUG=yes BUILD_DIR=$PWD/build/itst
     ```
 
 
@@ -107,11 +107,11 @@ These commands are used when middleware is set to Linux in mqttclient.conf.
 
     Variables:
     *   DEBUG: Set to yes for a debug build.
-    *   BUILD_DIR: Specifies the build directory for object files and final executable application.
+    *   BUILD_DIR: Specifies absolute path of the build directory for object files and final executable application.
 
     Example:
     ```
-    make demo DEBUG=yes
+    make demo DEBUG=yes BUILD_DIR=$PWD/build/itst
     ```
 
 
@@ -140,9 +140,9 @@ Note:
 
     Example:
     ```
-    make gen_3pty_libs -C ./third_party DEBUG=yes HW_PLATFORM=stm32f446 \
-        RTOS_HW_BUILD_PATH=/opt/mywork/tsunghan/Documents/os/rtos/rtos-playground \
-        TOOLCHAIN_BASEPATH=/usr/local/arm-gnu/14.2.rel1
+    make gen_3pty_libs DEBUG=yes HW_PLATFORM=stm32f446 \
+        RTOS_HW_BUILD_PATH=/path/to/code-repo/rtos-playground \
+        TOOLCHAIN_BASEPATH=/path/to/arm-gnu/14.2.rel1
     ```
 
 
@@ -152,7 +152,7 @@ Note:
 
     Variables:
     *   DEBUG: Set to yes for a debug build.
-    *   BUILD_DIR: Specifies the build directory for object files and output library `libmqttclient.a`.
+    *   BUILD_DIR: Specifies absolute path of the build directory for object files and output library `libmqttclient.a`.
     *   OS: Specifies the operating system (e.g., freertos-v10).
     *   HW_PLATFORM: Specifies the hardware platform (e.g., stm32f446).
     *   RTOS_HW_BUILD_PATH: Path to your RTOS hardware build environment.
@@ -162,10 +162,10 @@ Note:
 
     Example:
     ```
-    make gen_lib DEBUG=yes  BUILD_DIR=build/itst  OS=freertos-v10 HW_PLATFORM=stm32f446 \
-        RTOS_HW_BUILD_PATH=/opt/mywork/tsunghan/Documents/os/rtos/rtos-playground \
-        TOOLCHAIN_BASEPATH=/usr/local/arm-gnu/14.2.rel1 \
-        ESP_PROJ_HOME=/opt/mywork/tsunghan/Documents/c/network/wifi/ESP8266_AT_parser \
+    make gen_lib DEBUG=yes  BUILD_DIR=$PWD/build/itst  OS=freertos-v10 HW_PLATFORM=stm32f446 \
+        RTOS_HW_BUILD_PATH=/path/to/code-repo/rtos-playground \
+        TOOLCHAIN_BASEPATH=/path/to/arm-gnu/14.2.rel1 \
+        ESP_PROJ_HOME=/path/to/code-repo/ESP8266_AT_parser \
         APPCFG_BASEPATH=$PWD/tests/integration/cfg-os-hw
     ```
 
@@ -176,7 +176,7 @@ Note:
 
     Variables:
     *   DEBUG: Set to yes for a debug build.
-    *   BUILD_DIR: Specifies the build directory for object files and final executable application.
+    *   BUILD_DIR: Specifies absolute path of the build directory for object files and final executable application.
     *   OS: Specifies the operating system.
     *   HW_PLATFORM: Specifies the hardware platform.
     *   RTOS_HW_BUILD_PATH: Path to your RTOS hardware build environment.
@@ -187,10 +187,10 @@ Note:
 
     Example:
     ```
-    make buildapp DEBUG=yes OS=freertos-v10 HW_PLATFORM=stm32f446 \
-        RTOS_HW_BUILD_PATH=/opt/mywork/tsunghan/Documents/os/rtos/rtos-playground \
-        TOOLCHAIN_BASEPATH=/usr/local/arm-gnu/14.2.rel1 \
-        ESP_PROJ_HOME=/opt/mywork/tsunghan/Documents/c/network/wifi/ESP8266_AT_parser \
+    make buildapp DEBUG=yes BUILD_DIR=$PWD/build/itst  OS=freertos-v10 HW_PLATFORM=stm32f446 \
+        RTOS_HW_BUILD_PATH=/path/to/code-repo/rtos-playground \
+        TOOLCHAIN_BASEPATH=/path/to/arm-gnu/14.2.rel1 \
+        ESP_PROJ_HOME=/path/to/code-repo/ESP8266_AT_parser \
         APP_NAME=mqtt_connect \
         APP_BASEPATH=$PWD/tests/integration
     ```
@@ -205,9 +205,9 @@ Note:
     Example:
     ```
     make demo DEBUG=yes OS=freertos-v10 HW_PLATFORM=stm32f446 \
-        RTOS_HW_BUILD_PATH=/opt/mywork/tsunghan/Documents/os/rtos/rtos-playground \
-        TOOLCHAIN_BASEPATH=/usr/local/arm-gnu/14.2.rel1 \
-        ESP_PROJ_HOME=/opt/mywork/tsunghan/Documents/c/network/wifi/ESP8266_AT_parser
+        RTOS_HW_BUILD_PATH=/path/to/code-repo/rtos-playground \
+        TOOLCHAIN_BASEPATH=/path/to/arm-gnu/14.2.rel1 \
+        ESP_PROJ_HOME=/path/to/code-repo/ESP8266_AT_parser
     ```
 
 
@@ -226,7 +226,7 @@ These commands are specific to setting up a debugging session for STM32F4 platfo
     Example:
     ```
     make dbg_server HW_PLATFORM=stm32f446 \
-        RTOS_HW_BUILD_PATH=/opt/mywork/tsunghan/Documents/os/rtos/rtos-playground
+        RTOS_HW_BUILD_PATH=/path/to/code-repo/rtos-playground
     ```
 
 
@@ -243,8 +243,8 @@ These commands are specific to setting up a debugging session for STM32F4 platfo
     Example:
     ```
     make dbg_client HW_PLATFORM=stm32f446 \
-        RTOS_HW_BUILD_PATH=/opt/mywork/tsunghan/Documents/os/rtos/rtos-playground \
-        TOOLCHAIN_BASEPATH=/usr/local/arm-gnu/14.2.rel1 \
+        RTOS_HW_BUILD_PATH=/path/to/code-repo/rtos-playground \
+        TOOLCHAIN_BASEPATH=/path/to/arm-gnu/14.2.rel1 \
         GDB_SCRIPT_PATH=./auto/platform/utility.gdb
     ```
 
@@ -256,7 +256,7 @@ Here's a summary of important variables you might need to set on the command lin
 *   DEBUG: (yes/no, default no) Enables/disables debug symbols and potentially code coverage.
 *   MQC_PROJ_HOME: (Internal, set by $(shell pwd)) The absolute path to the root of the MQTT client project.
 *   MQC_CFG_FULLPATH: (Command line) The absolute path to the project configuration file. Mandatory for the `make config` target.
-*   BUILD_DIR: (Command line, default `build`) Determines the base path for all built object files, libraries, and executables. Can be applied to `make gen_lib`, `make buildapp`, and `make demo` for all supported middleware ports.
+*   BUILD_DIR: (Command line, default `build`) Determines the absolute base path for all built object files, libraries, and executables. Can be applied to `make gen_lib`, `make buildapp`, and `make demo` for all supported middleware ports.
 *   MIDDLEWARE: (From mqttclient.conf) The chosen middleware (e.g., Linux, ESP8266_AT_parser).
 *   HW_PLATFORM: (From mqttclient.conf or command line) The specific hardware platform (e.g., stm32f446).
 *   OS: (From mqttclient.conf or command line) The operating system (e.g., freertos-v10).

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ EXTRA_C_DEFS ?=
 
 DEBUG ?= no
 
-MQC_PROJ_HOME = $(shell pwd)
+MQC_PROJ_HOME ?= $(shell pwd)
 MQC_CFG_FULLPATH ?=
 
 ######################################
@@ -176,8 +176,8 @@ utest_helper : $(LIB_C_OBJS) $(TEST_COMMON_OBJECTS)  $(TEST_ENTRY_OBJECTS)
 
 # for unit test, no need to build library and test images using cross-compiler
 utest:
-	@make file_subst -C ./third_party;
-	@make utest_helper EXTRA_C_DEFS="MQTT_UNIT_TEST_MODE" DEBUG=$(DEBUG);
+	@make file_subst -C ./third_party MQC_PROJ_HOME=$(MQC_PROJ_HOME);
+	@make utest_helper DEBUG=$(DEBUG) EXTRA_C_DEFS="MQTT_UNIT_TEST_MODE";
 
 
 $(BUILD_DIR):
@@ -185,11 +185,8 @@ $(BUILD_DIR):
 
 clean:
 	@rm -rf $(BUILD_DIR)
-	@make clean -C ./third_party
+	@make clean -C ./third_party MQC_PROJ_HOME=$(MQC_PROJ_HOME)
 	@make clean -C auto/codegen/script  MQC_PROJ_HOME=$(MQC_PROJ_HOME)
-  
-download_3party:
-	@make download_3party -C  third_party
 
 config:
 	@if [ -z "$(MQC_CFG_FULLPATH)" ]; then \
@@ -202,6 +199,12 @@ config:
 		exit 1; \
 	fi
 	@make config -C  auto/codegen/script  MQC_PROJ_HOME=$(MQC_PROJ_HOME) MQC_CFG_FULLPATH=$(MQC_CFG_FULLPATH)
+  
+download_3party:
+	@make download_3party -C  third_party MQC_PROJ_HOME=$(MQC_PROJ_HOME)
+
+gen_3pty_libs:
+	@make gen_3pty_libs -C ./third_party  DEBUG=$(DEBUG) MQC_PROJ_HOME=$(MQC_PROJ_HOME)
 
 dbg_server:
 	@$(DBG_SERVER_CMD)

--- a/src/tls/core/tls_client.c
+++ b/src/tls/core/tls_client.c
@@ -218,6 +218,10 @@ mqttRespStatus mqttSecureNetconnStart(mqttCtx_t *mctx) {
     }
     if (tls_status < 0) {
         mctx->secure_session = NULL;
+        if (mctx->drbg != NULL) {
+            mqttDRBGdeinit(mctx->drbg);
+            mctx->drbg = NULL;
+        }
         tlsClientSessionDelete(session);
     }
     status = tlsRespCvtToMqttResp(tls_status);

--- a/tests/integration/build.mk
+++ b/tests/integration/build.mk
@@ -3,13 +3,17 @@ ITEST_FULLPATH = $(MQC_PROJ_HOME)/$(ITEST_REL_PATH)
 
 include  $(ITEST_FULLPATH)/cfg-os-hw/config.mk
 
+# TODO / FIXME
+# note that `APP_REQUIRED_C_HEADER_PATHS` and `APP_REQUIRED_C_SOURCE_FILES` are declared
+# in this code repository, ideally they should be encapsulated and never exposed to
+# external apps.
+
 APPCFG_C_INCLUDES = \
 	$(APP_REQUIRED_C_HEADER_PATHS) \
 	$(APPCFG_MIDDLEWARE_C_INCLUDES) \
     $(APPCFG_HW_C_INCLUDES)
 
-TEST_COMMON_SOURCES = $(ITEST_REL_PATH)/pattern_generator.c \
-					  generate/src/mqtt_generate.c
+TEST_COMMON_SOURCES = $(ITEST_REL_PATH)/pattern_generator.c
 
 APPCFG_C_SOURCES = \
 	$(APP_REQUIRED_C_SOURCE_FILES) \


### PR DESCRIPTION
- add path to auto-gen C source file at middleware layer, instead of placing it in application buils script
- update doc and github action workflow config