### PR TITLE
bufgix : fix Rx resume error in stm32 platform and add eESPlowLvlPower

### DIFF
--- a/src/system/middleware/ESP_AT_parser/mqtt_sys.c
+++ b/src/system/middleware/ESP_AT_parser/mqtt_sys.c
@@ -277,23 +277,31 @@ done:
 espRes_t eESPlowLvlRecvStartFn(void) {
     mqttRespStatus response = mqttPlatformPktRecvEnable();
     return mqttSysRespCvtToESPresp(response);
-} // end of  eESPlowLvlRecvStartFn
+}
 
-void vESPlowLvlRecvStopFn(void) { mqttPlatformPktRecvDisable(); } // end of vESPlowLvlRecvStopFn
+void vESPlowLvlRecvStopFn(void) { mqttPlatformPktRecvDisable(); }
 
 // the low-level functions that will be called when ESP AT parser (running on
 // host MCU board) sends raw bytes out .
 espRes_t eESPlowLvlSendFn(void *data, size_t len, uint32_t timeout) {
     mqttRespStatus response = mqttPlatformPktSend(data, len, timeout);
     return mqttSysRespCvtToESPresp(response);
-} // end of eESPlowLvlSendFn
+}
 
 // the low-level functions that will be called when MCU board reset (the hardware state)
 // of the ESP wifi module through hardware reset pin.
 espRes_t eESPlowLvlRstFn(uint8_t state) {
     mqttRespStatus response = mqttPlatformNetworkModRst(state);
     return mqttSysRespCvtToESPresp(response);
-} // end of eESPlowLvlRstFn
+}
+
+__attribute__((weak)) espRes_t eESPlowLvlPower(espFnEn_t en) {
+    // for usage or application example,
+    // check `tests/integration/src/hardware/stm32f446/stm32f446_config.c`
+    // in `ESP8266_AT_parser` code repository.
+    (void)en;
+    return espOK;
+}
 
 espRes_t eESPlowLvlDevInit(void *params) {
     mqttRespStatus response = mqttPlatformInit();

--- a/src/system/platform/arm/armv7m/stm/stm32f446.c
+++ b/src/system/platform/arm/armv7m/stm/stm32f446.c
@@ -143,12 +143,10 @@ done:
 
 mqttRespStatus mqttPlatformPktRecvEnable(void) {
     mqttRespStatus      response = MQTT_RESP_OK;
-    HAL_StatusTypeDef   status_chk = HAL_ERROR;
     UART_HandleTypeDef *uart_cfg = STM32_config_UART();
-    dma_buf_num_char_copied = 0;
-    dma_buf_cpy_offset_next = 0;
-    dma_buf_cpy_offset_curr = 0;
-    status_chk =
+    dma_buf_num_char_copied = dma_buf_cpy_offset_next = dma_buf_cpy_offset_curr = 0;
+    __HAL_UART_ENABLE(uart_cfg);
+    HAL_StatusTypeDef status_chk =
         HAL_UART_Receive_DMA(uart_cfg, (uint8_t *)&recv_data_buf[0], HAL_DMA_RECV_BUF_SIZE);
     switch (status_chk) {
     case HAL_OK:
@@ -172,10 +170,9 @@ mqttRespStatus mqttPlatformPktRecvEnable(void) {
 
 mqttRespStatus mqttPlatformPktRecvDisable(void) {
     mqttRespStatus      response = MQTT_RESP_OK;
-    HAL_StatusTypeDef   status_chk = HAL_ERROR;
     UART_HandleTypeDef *uart_cfg = STM32_config_UART();
-    status_chk = HAL_UART_DMAStop(uart_cfg);
-    ESP_MEMSET((void *)&recv_data_buf, 0x00, HAL_DMA_RECV_BUF_SIZE);
+    HAL_UART_AbortReceive(uart_cfg);
+    HAL_StatusTypeDef status_chk = HAL_UART_DMAStop(uart_cfg);
     switch (status_chk) {
     case HAL_OK:
         response = MQTT_RESP_OK;


### PR DESCRIPTION
- add `eESPlowLvlPower` hook function for ESP-AT-parser integration
- currently the low-level power-switch function is empty, the design should depend on application scenarios.